### PR TITLE
Fix/ausg logo

### DIFF
--- a/client/src/components/common/Banner.tsx
+++ b/client/src/components/common/Banner.tsx
@@ -2,7 +2,6 @@ import AwsIcons from "@ausg/components/molecules/AwsIcons";
 import React from "react";
 
 import BackgroundWaveSVG from "./BackgroundWaveSVG";
-import LogoWhiteSVG from "./LogoWhiteSVG";
 
 // TODO: 밑으로 스크롤을 안내하는 아이콘을 넣어주세요 - 다이빙하는 느낌으로 해주는 것도 좋을 듯?
 
@@ -10,8 +9,12 @@ const Banner: React.FC = () => {
   return (
     <div className="">
       <div className="header">
-        <div className="inner-header flex flex-col justify-center">
-          <LogoWhiteSVG width={400} className="mx-auto mt-20 mb-10" />
+        <div className="inner-header flex flex-col justify-center items-center">
+          <img
+            src="/images/logo-white.svg"
+            className="2xl:w-96 xl:w-80 lg:w-72 md:w-60 sm:w-48 w-36 mt-12"
+            alt="AUSG"
+          />
           <h1 className="text-5xl text-white typography mt-10 mx-20">
             AWSKRUG University Student Group
           </h1>

--- a/client/src/components/common/Header.tsx
+++ b/client/src/components/common/Header.tsx
@@ -24,9 +24,9 @@ const Header: React.FC = () => {
 
   return (
     <div className="header m-header">
-      <div className="doc_header">
+      <div className="doc_header md:px-7 px-4">
         <div className="flex items-center w-full max-w-screen-xl mx-auto">
-          <h1 className="doc_title">
+          <h1 className="doc_title flex-shrink-0">
             <Link href="/">
               <a className="link_logo" onClick={onClickHandlerForEasterEgg}>
                 <img

--- a/client/src/components/common/Header.tsx
+++ b/client/src/components/common/Header.tsx
@@ -32,7 +32,7 @@ const Header: React.FC = () => {
                 <img
                   src="/images/logo-white.svg"
                   alt="AUSG"
-                  className="img_logo"
+                  className="md:w-28 sm:w-24 w-20"
                 />
               </a>
             </Link>


### PR DESCRIPTION
- 메인 페이지 AUSG 로고를 SVG 이미지로 변경하고 Viewport 너비에 따라 크기가 변하도록 조정했습니다.
(viewport width 300px 스크린샷)
![스크린샷 2021-06-02 오전 10 54 46](https://user-images.githubusercontent.com/52230505/120412121-f5b63c80-c390-11eb-9311-e04dd006b523.png)

- 헤더의 AUSG 로고 또한 해상도에 맞춰 너비가 적절하게 유지되도록 조절했습니다.

- 모바일 해상도에서 헤더 양 옆 패딩이 16px이 되도록 조절했습니다. (기존에는 30px)