### PR TITLE
fix: remove codeowner for blog data posts json to be updated automatically

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
 *       @14km @SeongIkKim @suyeon96 @eunsukimme @victoriagjh @naru200 @roeniss
+
+# no owner for auto update (see ./github/updateBlogPostList.yml)
+/lib/blogSpider/newestPosts.json


### PR DESCRIPTION
`/.github/CODEOWNER` 때문에 약 3주간 블로그 최신글 페이지 (https://ausg.me/blog) 가 갱신되지 않은 것이 확인되었습니다.

github action dashboard: https://github.com/AUSG/Relay-Homepage/actions

따라서 크롤러가 갱신하는 파일만, PR 리뷰 없이 커밋이 가능하도록 CODEOWNER를 제거했습니다. 그런데 이 설정이 맞는지 잘 모르겠네요...

참고한 문서 : https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners