### PR TITLE
Feature/scrap ghost 블로그를 지원합니다.

### DIFF
--- a/lib/blogSpider/blogList.csv
+++ b/lib/blogSpider/blogList.csv
@@ -8,7 +8,7 @@ https://velog.io/@cadenzah,김정모,VELOG
 https://velog.io/@sian,이시연,VELOG
 https://velog.io/@p4rksh,박상훈,VELOG
 https://velog.io/@coffee-con,김민태,VELOG
-https://binaryflavor.com/,변준석,MEDIUM
+https://binaryflavor.com/rss,변준석,XML1,https://binaryflavor.com/
 https://k-dev.medium.com,고명진,MEDIUM
 https://suyeon96.tistory.com/,우수연,TISTORY1
 https://yebon-kim.tistory.com/,김예본,TISTORY2

--- a/lib/blogSpider/ioService/ioService.py
+++ b/lib/blogSpider/ioService/ioService.py
@@ -1,5 +1,4 @@
 import csv
-import toml
 import json
 
 from classes import Blog

--- a/lib/blogSpider/main.py
+++ b/lib/blogSpider/main.py
@@ -1,4 +1,5 @@
-import asyncio
+from asyncio import run as async_run
+
 from parsingService import parsingService
 from ioService import ioService
 
@@ -10,5 +11,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    async_run(main())

--- a/lib/blogSpider/parsingService/parsingService.py
+++ b/lib/blogSpider/parsingService/parsingService.py
@@ -1,12 +1,10 @@
 # -*- coding: utf8 -*-
-import time
 import asyncio
 import aiohttp
 from bs4 import BeautifulSoup
 import xml.etree.ElementTree as ET
-import requests
 
-from classes import Blog, BlogType, Post
+from classes import Post
 
 
 # Each parser


### PR DESCRIPTION
# 수정 내용
- Ghost 로 만들어진 블로그를 지원합니다.
    - 기존의 XML 파싱을 그대로 이용하면 됩니다.
- python 3.7부터 지원하는 API 인 [`asyncio.run`](https://docs.python.org/3/library/asyncio-task.html#asyncio.run)을 사용하도록 수정합니다. 더 직관적인 `main()` 콜이 됩니다.
- 사용하지 않는 임포트 문을 제거합니다.